### PR TITLE
Fix tests to prepare for upcoming leaflet v2.2.0 release

### DIFF
--- a/tests/testthat/test-controls.R
+++ b/tests/testthat/test-controls.R
@@ -17,8 +17,10 @@ testthat::test_that("Initialize map dependencies in addOpacitySlider", {
     addRasterImage(r, layerId = "raster", project = FALSE) %>%
     addOpacitySlider(layerId = "raster")
 
-  expect_equal(res$dependencies[[1]]$name, "jquery-ui")
-  expect_equal(res$dependencies[[2]]$name, "opacity")
+  expect_contains(
+    vapply(res$dependencies, function(x) x$name, character(1)),
+    c("jquery-ui", "opacity")
+  )
 })
 
 testthat::test_that("Initialize map dependencies in addLowerOpacity", {
@@ -33,8 +35,10 @@ testthat::test_that("Initialize map dependencies in addLowerOpacity", {
     addRasterImage(r, layerId = "raster", project = FALSE) %>%
     addLowerOpacity(layerId = "raster")
 
-  expect_equal(res$dependencies[[1]]$name, "jquery-ui")
-  expect_equal(res$dependencies[[2]]$name, "opacity")
+    expect_contains(
+      vapply(res$dependencies, function(x) x$name, character(1)),
+      c("jquery-ui", "opacity")
+    )
 })
 
 testthat::test_that("Initialize map dependencies in addHigherOpacity", {
@@ -49,8 +53,10 @@ testthat::test_that("Initialize map dependencies in addHigherOpacity", {
     addRasterImage(r, layerId = "raster", project = FALSE) %>%
     addHigherOpacity(layerId = "raster")
 
-  expect_equal(res$dependencies[[1]]$name, "jquery-ui")
-  expect_equal(res$dependencies[[2]]$name, "opacity")
+    expect_contains(
+      vapply(res$dependencies, function(x) x$name, character(1)),
+      c("jquery-ui", "opacity")
+    )
 })
 
 testthat::test_that("Add javascript code with addOpacitySlider", {


### PR DESCRIPTION
Hi @be-marc! We're preparing the next release of leaflet (v2.2.0, rstudio/leaflet#876) and noticed that our updates break a few tests in your package.

I've provided a fix in this PR. In essence, `leaflet()` now includes its own dependencies in the `dependencies` item of the returned htmlwidgets object, which means that it contains both our dependencies and the dependencies your extension has added. The updated test now finds the name of all dependencies in the object and ensures that `jquery-ui` and `opacity` are included. This ensures that they're included in the list of dependencies, but you may want to add an additional check to test that they're included in that order (if that's important to your extension).

Do you think you'd be able to update your package on CRAN in the next two weeks? We're planning on submitting leaflet v2.2.0 on Tuesday, August 29 at the latest and are hoping we can have all reverse dependencies issues worked out by then. Thanks!